### PR TITLE
Solved the bug for validating urls returning status code other than 200

### DIFF
--- a/server/middlewares/url.js
+++ b/server/middlewares/url.js
@@ -1,30 +1,45 @@
 const https = require("node:https");
 
-async function checkWebsite(url) {
-  try {
-    const response = await new Promise((resolve, reject) => {
-      const options = {
-        method: "GET",
-        headers: {
-          "User-Agent": "Mozilla/5.0", // Set a User-Agent header to mimic a real web browser
-          Accept:
-            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-          "Accept-Encoding": "gzip, deflate, br",
-          Connection: "keep-alive",
-        },
-      };
-      https
-        .get(url, options, (res) => {
-          resolve(res);
-        })
-        .on("error", (e) => {
-          reject(e);
-        });
-    });
-    return response.statusCode === 200;
-  } catch (error) {
-    return false;
+const VALID_STATUS_CODES = new Set(
+  [...Array.from({ length: 100 }, (_, i) => 200 + i), // 2xx codes
+  ...Array.from({ length: 100 }, (_, i) => 300 + i), // 3xx codes
+  999 ]
+);
+
+async function checkWebsite(url, retries = 3) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await new Promise((resolve, reject) => {
+        const options = {
+          method: "GET",
+          headers: {
+            "User-Agent": "Mozilla/5.0",
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br",
+            Connection: "keep-alive",
+          },
+        };
+        https
+          .get(url, options, (res) => {
+            resolve(res);
+          })
+          .on("error", (e) => {
+            reject(e);
+          });
+      });
+
+      // Check if status code is in the set of valid status codes
+      if (VALID_STATUS_CODES.has(response.statusCode)) {
+        return true;
+      }
+    } catch (error) {
+      console.error("Error:", error);
+    }
   }
+
+  // If all retries fail or status code is not valid
+  return false;
 }
 
 const isValidURL = async (req, res, next) => {


### PR DESCRIPTION
Fixes: #137

Description:
This pull request addresses the issue where the URL validation logic in the isValidURL middleware incorrectly considers URLs as valid even when the HTTP status code is not 200. The fix modifies the checkWebsite function to properly handle status codes other than 200, ensuring accurate URL validation by defining a set of Valid URL's and a retry mechanism upto 3 times

Tests:
Conducted manual testing to ensure that URLs with non-200 status codes are correctly identified as invalid by the isValidURL middleware.

Test 1:
Input url: https://www.linkedin.com/in/srikarmellachervu/
Status Code: 999
Output:
![sol](https://github.com/abhijeetnishal/URLShortener/assets/101891231/8bb1d483-9742-419e-97ac-7bd9a5bf34a9)

Test 2:
Input url: https://redis.io/docs/latest/develop/use/
Status code: 200
Output: 
![sol2](https://github.com/abhijeetnishal/URLShortener/assets/101891231/b6f2e62b-d5a7-469f-8c95-5a6a63d19284)